### PR TITLE
Add forgotten err assignment

### DIFF
--- a/server/server_nonce.go
+++ b/server/server_nonce.go
@@ -124,10 +124,5 @@ func deleteExpired(c context.Context, now time.Time, parentKey *datastore.Key) e
 	}
 
 	log.Infof(c, "Delete %v expired nonces", len(keys))
-	datastore.DeleteMulti(c, keys)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return datastore.DeleteMulti(c, keys)
 }


### PR DESCRIPTION
Looking at the error check below, it looks like we wanted to handle
the error coming from DeleteMulti, but forgot to assign the var.

Please review this thoroughly. Should we indeed want to ignore this
error, we should remove the error check below as err can't ever be
non-nil here.