### PR TITLE
Add Windows as release target to .goreleaser.yml

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,6 +11,7 @@ builds:
     goos:
       - linux
       - darwin
+      - windows
     goarch:
       - amd64
       - arm64


### PR DESCRIPTION
Builds fine on x86 / 64. Untested on Windows.